### PR TITLE
LineageStats: explicitly cancel old jobs

### DIFF
--- a/src/org/lineageos/lineageparts/lineagestats/AnonymousStats.java
+++ b/src/org/lineageos/lineageparts/lineagestats/AnonymousStats.java
@@ -49,7 +49,7 @@ public class AnonymousStats extends SettingsPreferenceFragment {
                 .commit();
     }
 
-    private static int getLastJobId(Context context) {
+    public static int getLastJobId(Context context) {
         return getPreferences(context).getInt(KEY_LAST_JOB_ID, 0);
     }
 

--- a/src/org/lineageos/lineageparts/lineagestats/ReportingService.java
+++ b/src/org/lineageos/lineageparts/lineagestats/ReportingService.java
@@ -45,6 +45,7 @@ public class ReportingService extends IntentService {
         String deviceCarrier = Utilities.getCarrier(getApplicationContext());
         String deviceCarrierId = Utilities.getCarrierId(getApplicationContext());
 
+        final int lineageOldJobId = AnonymousStats.getLastJobId(getApplicationContext());
         final int lineageOrgJobId = AnonymousStats.getNextJobId(getApplicationContext());
 
         if (DEBUG) Log.d(TAG, "scheduling job id: " + lineageOrgJobId);
@@ -70,6 +71,9 @@ public class ReportingService extends IntentService {
                 .setExtras(lineageBundle)
                 .setPersisted(true)
                 .build());
+
+        // cancel old job in case it didn't run yet
+        js.cancel(lineageOldJobId);
 
         // reschedule
         AnonymousStats.updateLastSynced(this);


### PR DESCRIPTION
* A new job gets scheduled every day or at reboot
* In case an user does not have a network connection, the jobs stack up as per AOSP documentation of setRequiredNetworkType
* We only want to report to the server once, so there is no need to keep old jobs any longer, we therefore cancel the old jobs

Change-Id: I3c6baaf3b10658aa2e49b8ac8d207aa9eac82772