### PR TITLE
livedisplay: Don't show duplicate title in LiveDisplay options

### DIFF
--- a/res/xml/livedisplay.xml
+++ b/res/xml/livedisplay.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
      Copyright (C) 2015 The CyanogenMod Project
-                   2018 The LineageOS Project
+                   2018-2019 The LineageOS Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -20,8 +20,7 @@
         android:title="@*lineageos.platform:string/live_display_title">
 
     <PreferenceCategory
-        android:key="live_display_options"
-        android:title="@*lineageos.platform:string/live_display_title">
+        android:key="live_display_options">
 
         <!-- Color profile -->
         <ListPreference


### PR DESCRIPTION
 * It's enough to show the preferencescreen title.

Change-Id: I74d555a133da398a5b67ec25490741d55b0ee02f